### PR TITLE
Added fix to support --x86-only in docker environment

### DIFF
--- a/src/exrmod/gisobuild_docker_exr.py
+++ b/src/exrmod/gisobuild_docker_exr.py
@@ -53,6 +53,10 @@ def system_resource_prep (args):
     args_dict["out_directory"] = str(_CTR_OUT_DIR)
     args_dict["create_checksum"] = True
     
+    ''' if x86_only option is supplied to build GISO with x86_64 rpm only '''
+    if args.x86_only:
+        args_dict["x86_only"] = True
+
     ''' Copy the giso config, ztp.ini and script to temp staging. '''
     if args.xrconfig:
         shutil.copy (args.xrconfig, tempdir)

--- a/src/utils/yamlparser.py
+++ b/src/utils/yamlparser.py
@@ -262,7 +262,7 @@ class Options:
             migration = ydict.get("migration", False)
             optimize = ydict.get("optimize", False)
             fullISO = ydict.get("full-iso", False)
-            x86_only = ydict.get("x86-only", False)
+            x86_only = ydict.get("x86_only", False)
             isoinfo = ydict.get("isoinfo", None)
             image_script = ydict.get("image_script", None)
 


### PR DESCRIPTION
Added fix to support --x86-only in docker environment

Fix is specific to exr

[08:14:19]-[cmohapat@sjc-ads-7030:/nobackup/cmohapat/exr/image/ncs540_752-v1]$ /nobackup/cmohapat/exr/code/GISO/extgisocodefix/src/gisobuild.py --iso ncs540-mini-x-7.5.2.iso --repo rpms/ --label test --clean --x86-only --docker
Setting up container environment...
Reuse matching image, cisco-xr-gisobuild:2.3.3
/
Running GISO build...
|System requirements check [PASS]
Platform: ncs540 Version: 7.5.2
Scanning repository [/nobackup/cmohapat/exr/image/ncs540_752-v1/rpms]...
Building RPM Database...
Total 18 RPM(s) present in the repository path provided in CLI
[ 1] ncs540-li-1.0.0.0-r752.x86_64.rpm
[ 2] ncs540-dpa-1.0.0.1-r752.CSCwc89630.x86_64.rpm
[ 3] ncs540-sysadmin-system-7.5.2.1-r752.CSCwc64271.x86_64.rpm
[ 4] ncs540-mpls-1.0.0.0-r752.x86_64.rpm
[ 5] ncs540-mgbl-1.0.0.0-r752.x86_64.rpm
[ 6] ncs540-eigrp-1.0.0.0-r752.x86_64.rpm
[ 7] ncs540-fwding-2.0.0.2-r752.CSCwc20705.x86_64.rpm
[ 8] ncs540-dpa-fwding-2.0.0.2-r752.CSCwc00647.x86_64.rpm
[ 9] ncs540-mcast-1.0.0.0-r752.x86_64.rpm
[10] ncs540-mpls-te-rsvp-1.0.0.0-r752.x86_64.rpm
[11] ncs540-k9sec-1.1.0.0-r752.x86_64.rpm
[12] ncs540-sysadmin-hostos-7.5.2.1-r752.CSCwc03249.admin.x86_64.rpm
[13] ncs540-lictrl-1.0.0.0-r752.x86_64.rpm
[14] ncs540-infra-2.0.0.2-r752.CSCwb74098.x86_64.rpm
[15] ncs540-isis-1.0.0.0-r752.x86_64.rpm
[16] ncs540-sysadmin-hostos-7.5.2.1-r752.CSCwc03249.host.x86_64.rpm
[17] ncs540-ospf-1.0.0.0-r752.x86_64.rpm
[18] ncs540-iosxr-fwding-2.0.0.2-r752.CSCwb19707.x86_64.rpm
Following XR x86_64 rpm(s) will be used for building Golden ISO:
        (+) ncs540-li-1.0.0.0-r752.x86_64.rpm
        (+) ncs540-dpa-1.0.0.1-r752.CSCwc89630.x86_64.rpm
        (+) ncs540-mpls-1.0.0.0-r752.x86_64.rpm
        (+) ncs540-mgbl-1.0.0.0-r752.x86_64.rpm
        (+) ncs540-eigrp-1.0.0.0-r752.x86_64.rpm
        (+) ncs540-fwding-2.0.0.2-r752.CSCwc20705.x86_64.rpm
        (+) ncs540-dpa-fwding-2.0.0.2-r752.CSCwc00647.x86_64.rpm
        (+) ncs540-mcast-1.0.0.0-r752.x86_64.rpm
        (+) ncs540-mpls-te-rsvp-1.0.0.0-r752.x86_64.rpm
        (+) ncs540-k9sec-1.1.0.0-r752.x86_64.rpm
        (+) ncs540-lictrl-1.0.0.0-r752.x86_64.rpm
        (+) ncs540-infra-2.0.0.2-r752.CSCwb74098.x86_64.rpm
        (+) ncs540-isis-1.0.0.0-r752.x86_64.rpm
        (+) ncs540-ospf-1.0.0.0-r752.x86_64.rpm
        (+) ncs540-iosxr-fwding-2.0.0.2-r752.CSCwb19707.x86_64.rpm
        ...RPM signature check [PASS]
        ...RPM compatibility check [PASS]
Following SYSADMIN x86_64 rpm(s) will be used for building Golden ISO:
        (+) ncs540-sysadmin-system-7.5.2.1-r752.CSCwc64271.x86_64.rpm
        (+) ncs540-sysadmin-hostos-7.5.2.1-r752.CSCwc03249.admin.x86_64.rpm
Skipping arm rpms as given x86_only option
        ...RPM signature check [PASS]
        ...RPM compatibility check [PASS]
Following HOST x86_64 rpm(s) will be used for building Golden ISO:
        (+) ncs540-sysadmin-hostos-7.5.2.1-r752.CSCwc03249.host.x86_64.rpm
Skipping arm rpms as given x86_only option
        ...RPM signature check [PASS]
        ...RPM compatibility check [PASS]
Building Golden ISO...
Summary .....
XR rpms:
        ncs540-li-1.0.0.0-r752.x86_64.rpm
        ncs540-dpa-1.0.0.1-r752.CSCwc89630.x86_64.rpm
        ncs540-mpls-1.0.0.0-r752.x86_64.rpm
        ncs540-mgbl-1.0.0.0-r752.x86_64.rpm
        ncs540-eigrp-1.0.0.0-r752.x86_64.rpm
        ncs540-fwding-2.0.0.2-r752.CSCwc20705.x86_64.rpm
        ncs540-dpa-fwding-2.0.0.2-r752.CSCwc00647.x86_64.rpm
        ncs540-mcast-1.0.0.0-r752.x86_64.rpm
        ncs540-mpls-te-rsvp-1.0.0.0-r752.x86_64.rpm
        ncs540-k9sec-1.1.0.0-r752.x86_64.rpm
        ncs540-lictrl-1.0.0.0-r752.x86_64.rpm
        ncs540-infra-2.0.0.2-r752.CSCwb74098.x86_64.rpm
        ncs540-isis-1.0.0.0-r752.x86_64.rpm
        ncs540-ospf-1.0.0.0-r752.x86_64.rpm
        ncs540-iosxr-fwding-2.0.0.2-r752.CSCwb19707.x86_64.rpm
SYSADMIN rpms:
        ncs540-sysadmin-system-7.5.2.1-r752.CSCwc64271.x86_64.rpm
        ncs540-sysadmin-hostos-7.5.2.1-r752.CSCwc03249.admin.x86_64.rpm
HOST rpms:
        ncs540-sysadmin-hostos-7.5.2.1-r752.CSCwc03249.host.x86_64.rpm
        ...Golden ISO creation SUCCESS.
Golden ISO Image Location: /tmp/output_gisobuild-2a9o8c1x/ncs540-goldenk9-x-7.5.2-test_Fixed.iso

Done...
Build artefacts copied to /nobackup/cmohapat/exr/image/ncs540_752-v1/output_gisobuild
Logs copied to /nobackup/cmohapat/exr/image/ncs540_752-v1/output_gisobuild/logs/221021-081424-404005
Verifying checksums...
Checksums OK
[08:27:27]-[cmohapat@sjc-ads-7030:/nobackup/cmohapat/exr/image/ncs540_752-v1]$