### PR TITLE
GISO USB zip is enabled for NCS540

### DIFF
--- a/src/exrmod/usb_zip/platform_scripts.yaml
+++ b/src/exrmod/usb_zip/platform_scripts.yaml
@@ -1,1 +1,2 @@
 ncs5500: "create_usb_zip"
+ncs540: "create_usb_zip"


### PR DESCRIPTION
Syncing of internal Github to external Github. GISO USB/ zip for ncs540 is enabled.